### PR TITLE
Feat: Set root user password

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ Create a database
           database: testdb
 ```
 
+Set MySQL's `root` user password:
+
+```yml
+      - uses: ankane/setup-mariadb@v1
+        with:
+          root-user-password: SuperSecretPassword
+```
+
 ## Extra Steps
 
 Run queries
@@ -86,3 +94,9 @@ Everyone is encouraged to help improve this project. Here are a few ways you can
 - Fix bugs and [submit pull requests](https://github.com/ankane/setup-mariadb/pulls)
 - Write, clarify, or fix documentation
 - Suggest or add new features
+
+
+## Notes
+
+- A database user named `runneradmin` is created, with no password, who has all privleges. 
+- MySQL's `root` user has no password by default. A password can be added by using the action input `root-user-password`.

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,8 @@ inputs:
     description: The MariaDB version to download (if necessary) and use
   database:
     description: Database to create
+  root-user-password:
+    description: Password to set for the MySQL root user. Do not use a production password
 runs:
   using: node16
   main: index.js

--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ if (!['10.10', '10.9', '10.8', '10.7', '10.6', '10.5', '10.4', '10.3'].includes(
 }
 
 const database = process.env['INPUT_DATABASE'];
+const rootPassword = process.env['INPUT_ROOT-USER-PASSWORD'] || '';
 
 let bin;
 
@@ -71,6 +72,7 @@ if (isMac()) {
     run(`${bin}/mysql -u root -e "GRANT ALL PRIVILEGES ON *.* TO ''@'localhost'"`);
     run(`${bin}/mysql -u root -e "FLUSH PRIVILEGES"`);
   }
+
 } else if (isWindows()) {
   // install
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mariadb-'));
@@ -96,6 +98,7 @@ if (isMac()) {
   run(`"${bin}\\mysql" -u root -e "CREATE USER 'runneradmin'@'localhost' IDENTIFIED BY ''"`);
   run(`"${bin}\\mysql" -u root -e "GRANT ALL PRIVILEGES ON *.* TO 'runneradmin'@'localhost'"`);
   run(`"${bin}\\mysql" -u root -e "FLUSH PRIVILEGES"`);
+
 } else {
   const image = process.env['ImageOS'];
   if (image == 'ubuntu20' || image == 'ubuntu22') {
@@ -127,4 +130,9 @@ if (isMac()) {
 
 if (database) {
   runSafe(path.join(bin, 'mysqladmin'), 'create', database);
+}
+
+// set root password if specified
+if (rootPassword) {
+  runSafe(path.join(bin, 'mysqladmin'), '-uroot', 'password', rootPassword);
 }


### PR DESCRIPTION
Set root user password via input `root-user-password` to support testing pipelines that expect a password for the root user.

The workaround before this was to call a separate `run` action to set the password.